### PR TITLE
Avira AntiVirus Logs

### DIFF
--- a/Targets/AviraAVLogs.tkape
+++ b/Targets/AviraAVLogs.tkape
@@ -1,0 +1,13 @@
+Description: Avira Logs
+Author: Fabian Murer
+Version: 1.0
+Id: f977c6c9-378b-4812-a5ca-1f6c5fe57b18
+RecreateDirectories: true
+Targets:
+    -
+        Name: Avira Activity Logs
+        Category: AntiVirus
+        Path: C:\ProgramData\Avira\Antivirus\LOGFILES
+        IsDirectory: true
+        Recursive: true
+        Comment: "Collects the scan logs of Avira AntiVirus"


### PR DESCRIPTION
Target to collect the scan logs of Avira AntiVirus. Location according to https://support.avira.com/hc/de/community/posts/360006303377-How-To-Check-My-Scan-Logs